### PR TITLE
correctly deal with syntax error

### DIFF
--- a/autoload/python/coqide/stm.py
+++ b/autoload/python/coqide/stm.py
@@ -292,6 +292,7 @@ class STM:
         res, err = self._get_value_response('add')
 
         if err:
+            self._view.show_message('error', err['message'])
             state = _State(StateID(-1), sentence, self._view)
             state.set_flag('error', loc=err['loc'])
         else:
@@ -300,7 +301,7 @@ class STM:
 
         self._state_list.insert(self._tip_state, state)
 
-        if res['closed_proof']:
+        if res != None and res['closed_proof']:
             next_id = res['closed_proof']['next_state_id']
             next_state = self._state_list.find_by_id(next_id)
             self._tip_state = next_state


### PR DESCRIPTION
The plugin breaks down when users accidentally submit some ill-formed Coq terms or sentences.
`coqtop` wouldn't return a feedback message together with a value message in this situation. Rather, it  responds with a single value message, e.g: `<value loc_e="6" loc_s="0" val="fail"><state_id val="0" /><richpp><_><pp>Syntax error: illegal begin of vernac.</pp></_></richpp></value>` .
When encountered with such response, function `_add_res_from_xml` in `xmlprotocol.py` returns `None` (which causes the plugin to break down) and pass forward the error mesages.

I add necessary judgement to avoid the exception, and let it shows syntax-error messages.